### PR TITLE
Enable SSR prerendering for SEO

### DIFF
--- a/src/routes/+layout.js
+++ b/src/routes/+layout.js
@@ -1,3 +1,1 @@
-// Disable SSR for client-only app
-export const ssr = false;
 export const prerender = true;

--- a/src/routes/robots.txt/+server.ts
+++ b/src/routes/robots.txt/+server.ts
@@ -1,0 +1,18 @@
+import { base } from '$app/paths';
+
+const SITE_URL = 'https://miclip.github.io' + base;
+
+export const prerender = true;
+
+export function GET() {
+	const body = `User-agent: *
+Allow: /
+
+Sitemap: ${SITE_URL}/sitemap.xml`;
+
+	return new Response(body, {
+		headers: {
+			'Content-Type': 'text/plain'
+		}
+	});
+}

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,0 +1,29 @@
+import { base } from '$app/paths';
+
+const SITE_URL = 'https://miclip.github.io' + base;
+
+const pages = ['', '/docs'];
+
+export const prerender = true;
+
+export function GET() {
+	const urls = pages
+		.map(
+			(page) => `
+  <url>
+    <loc>${SITE_URL}${page}</loc>
+    <changefreq>weekly</changefreq>
+  </url>`
+		)
+		.join('');
+
+	const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urls}
+</urlset>`;
+
+	return new Response(sitemap.trim(), {
+		headers: {
+			'Content-Type': 'application/xml'
+		}
+	});
+}

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -8,7 +8,6 @@ const config = {
 		adapter: adapter({
 			pages: 'build',
 			assets: 'build',
-			fallback: 'index.html',
 			precompress: false,
 			strict: true
 		}),


### PR DESCRIPTION
## Summary
- **Enable SSR during prerendering** by removing `ssr = false` from `+layout.js` — prerendered HTML now contains full page content instead of empty shells, making it crawlable by search engines
- **Remove SPA fallback** (`fallback: 'index.html'`) from adapter-static config since all routes are properly prerendered
- **Add `sitemap.xml`** and **`robots.txt`** as prerendered server endpoints that respect the `BASE_PATH` for GitHub Pages deployment

## Test plan
- [x] `vite build` succeeds and generates `build/index.html`, `build/docs.html`, `build/sitemap.xml`, and `build/robots.txt`
- [ ] Verify prerendered HTML contains page content (not empty shell)
- [ ] Verify sitemap URLs include correct base path after GitHub Pages deploy
- [ ] Verify robots.txt references correct sitemap URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)